### PR TITLE
Fix #8 🏁

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You no longer have to run your entire test suite for that one test you changed ð
 | Option              | Description                                                                                                         |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | Jest Config Path         | Jest config file path relative to the current workspace (e.g: ./jest.config.js)                                     |
-| Jest Path                | Absolute path to the Jest binary (default: node_modules/.bin/jest) |
+| Jest Path                | Absolute path to the Jest binary |
 | Run Test Label           | Label for the run test action |
 | Debug Test Label         | Label for the debug test action |
 | Update Snapshosts Label  | Label for update snapshots action |

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
           },
           "jestRunIt.jestPath": {
             "type": "string",
-            "default": "node_modules/.bin/jest",
-            "description": "Absolute path to the Jest binary (default: node_modules/.bin/jest)",
+            "default": "",
+            "description": "Absolute path to the Jest binary",
             "scope": "window"
           },
           "jestRunIt.runTestLabel": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,22 @@
+import {getDefaultJestPathForOS} from './helper';
+
 export const DEFAULT_TEST_FILE_PATTERNS = [
   '**/*.{test,spec}.{js,jsx,ts,tsx}',
   '**/__tests__/*.{js,jsx,ts,tsx}',
 ];
 
-export const DEFAULT_JEST_PATH = 'node_modules/.bin/jest';
+const DEFAULT_OS_JEST_PATH: { [os: string]: string } = {
+  LINUX: 'node_modules/.bin/jest',
+  MAC: 'node_modules/.bin/jest',
+  /**
+   * Issue #8
+   *
+   * Solution from Stack Overflow
+   * @see https://stackoverflow.com/questions/3903288/run-an-exe-from-a-different-directory/3903300#3903300 Stack Overflow
+   */
+  WINDOWS:'\"node_modules/.bin/jest\"'
+};
+
+export const DEFAULT_JEST_PATH = getDefaultJestPathForOS(DEFAULT_OS_JEST_PATH);
 
 export const TERMINAL_NAME = 'JestRunIt';

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,0 +1,55 @@
+import {platform} from 'os';
+
+/**
+ * Get the default Jest path based on the OS
+ * @param LINUX Linux path
+ * @param MAC MacOS path
+ * @param WINDOWS Windows Path
+ */
+export const getDefaultJestPathForOS = ({LINUX, MAC, WINDOWS}: { [os: string]: string }): string => {
+  const osPlatform = platform();
+
+  if (isWindows(osPlatform)) {
+    return WINDOWS;
+  }
+
+  if (isMacOS(osPlatform)) {
+    return MAC;
+  }
+
+  return LINUX;
+};
+
+
+/**
+ * Check out linux platform
+ */
+const isLinux = (p: NodeJS.Platform) => {
+  const platforms = [
+    'aix',
+    'android',
+    'linux',
+  ];
+
+  return platforms.indexOf(p) >= 0;
+};
+
+/**
+ * Check out MacOS platform
+ */
+const isMacOS = (p: NodeJS.Platform) => {
+  const platforms = [
+    'darwin',
+    'freebsd',
+  ];
+
+  return platforms.indexOf(p) >= 0;
+};
+
+/**
+ * Check out Windows platform
+ */
+const isWindows = function (p: NodeJS.Platform) {
+  return p && p.match(/^win/) !== null;
+};
+


### PR DESCRIPTION
FIx #8 

**Why I Removed the default value from `jestRunIt.jestPath`:**
I removed the default value because it would never use the default OS-specific value

