### PR TITLE
Jest does not find tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,36 @@ You no longer have to run your entire test suite for that one test you changed ð
 2. Open the test file.
 3. Run tests.
 
-## Troubleshooting.
+## Troubleshooting
 
 1. You don't see the run/link buttons:
    If you are not seeing the buttons for running the tests, it could be because the plugin did not recognize the file as a test file. You need to update the test match patterns so that it will be recognized as a test file. See the [config options](#config-options) section to see more details.
 
 2. Your Jest is installed differently:
    There is a config option to specify your Jest path. See the [config options](#config-options).
+
+3. Jest does not match your test when you run it from the CodeLens
+   Jest on Windows has different treatment for single and double quotes in command-line arguments.
+
+   The following command may NOT work on Windows because test name is wrapped with apostrophee:
+   `node_modules\.bin\jest 'c:/samples/my service/test/get-data.spec.js'`
+
+   ```console
+   No tests found, exiting with code 1
+   Run with `--passWithNoTests` to exit with code 0
+   In C:\samples\my service
+   53 files checked.
+   testMatch: **/__tests__/**/*.[jt]s?(x), **/?(*.)+(spec|test).[tj]s?(x) - 1 match
+   testPathIgnorePatterns: \\node_modules\\ - 35 matches
+   testRegex:  - 0 matches
+   Pattern: 'c:\\samples\\my service\\test\\get-data.spec.js' - 0 matches
+   ```
+
+   Wrapping file name with quotation marks solves the problem:
+   `node_modules\.bin\jest "c:/samples/my service/test/get-data.spec.js"`
+
+   There is a config option to control quotation marks to use in command-line arguments.
+   See the [config options](#config-options).
 
 ## Config Options
 
@@ -36,6 +59,7 @@ You no longer have to run your entire test suite for that one test you changed ð
 | Update Snapshosts Label  | Label for update snapshots action |
 | Custom Snapshot Matchers | Custom snapshot matchers |
 | Test Match Patterns | Glob patterns to match test files (default: ['**/*.{test,spec}.{js,jsx,ts,tsx}', '**/__tests__/*.{js,jsx,ts,tsx}']) |
+| Argument Quotes To Use | Quotation marks to use in command-line arguments: 'auto', 'single', 'double' or 'none' |
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,13 @@
             ],
             "description": "Glob patterns to match test files",
             "scope": "window"
+		  },
+          "jestRunIt.argumentQuotesToUse": {
+			"type": "string",
+			"enum": ["none", "auto", "single", "double"],
+            "default": "auto",
+            "description": "Quotes to use when preparing arguments for jest",
+            "scope": "window"
           }
         }
       }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,12 +2,12 @@ import * as vscode from 'vscode';
 
 import { DEFAULT_JEST_PATH, TERMINAL_NAME } from './constants';
 import { getConfig, ConfigOption } from './config';
-import { quoteTestName, getTerminal } from './extension';
+import { quoteTestName, getTerminal, quoteArgument } from './extension';
 
 export const runTest = (filePath: string, testName?: string, updateSnapshots = false) => {
   const jestPath = getConfig(ConfigOption.JestPath) || DEFAULT_JEST_PATH;
   const jestConfigPath = getConfig(ConfigOption.JestConfigPath);
-  let command = `${jestPath} ${quoteTestName(filePath)}`;
+  let command = `${jestPath} ${quoteArgument(filePath)}`;
   if (testName) {
     command += ` -t ${quoteTestName(testName)}`;
   }
@@ -30,7 +30,7 @@ export const debugTest = (filePath: string, testName?: string) => {
   const jestConfigPath = getConfig(ConfigOption.JestConfigPath);
   const args = [filePath];
   if (testName) {
-    args.push('-t', quoteTestName(testName));
+    args.push('-t', quoteArgument(testName));
   }
   if (jestConfigPath) {
     args.push('-c', jestConfigPath as string);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,7 +30,7 @@ export const debugTest = (filePath: string, testName?: string) => {
   const jestConfigPath = getConfig(ConfigOption.JestConfigPath);
   const args = [filePath];
   if (testName) {
-    args.push('-t', quoteArgument(testName));
+    args.push('-t', quoteTestName(testName, 'none'));
   }
   if (jestConfigPath) {
     args.push('-c', jestConfigPath as string);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { DEFAULT_JEST_PATH, TERMINAL_NAME } from './constants';
+import { DEFAULT_JEST_PATH, DEFAULT_JEST_DEBUG_PATH_WINDOWS, TERMINAL_NAME } from './constants';
 import { getConfig, ConfigOption } from './config';
 import { quoteTestName, getTerminal, quoteArgument } from './extension';
 
@@ -26,7 +26,8 @@ export const runTest = (filePath: string, testName?: string, updateSnapshots = f
 };
 export const debugTest = (filePath: string, testName?: string) => {
   const editor = vscode.window.activeTextEditor;
-  const jestPath = getConfig(ConfigOption.JestPath) || DEFAULT_JEST_PATH;
+  const jestPath = getConfig(ConfigOption.JestPath)
+  	|| (process.platform === 'win32' ? DEFAULT_JEST_DEBUG_PATH_WINDOWS : DEFAULT_JEST_PATH);
   const jestConfigPath = getConfig(ConfigOption.JestConfigPath);
   const args = [filePath];
   if (testName) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export enum ConfigOption {
   UpdateSnapshotsLabel = 'updateSnapshotsLabel',
   TestMatchPatterns = 'testMatchPatterns',
   CustomSnapshotMatchers = 'customSnapshotMatchers',
+  ArgumentQuotesToUse = 'argumentQuotesToUse',
 }
 
 export type JestRunItConfig = Omit<

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const DEFAULT_TEST_FILE_PATTERNS = [
   '**/__tests__/*.{js,jsx,ts,tsx}',
 ];
 
-export const DEFAULT_JEST_PATH =path.join('node_modules','.bin', 'jest');
+export const DEFAULT_JEST_PATH = path.join('node_modules','.bin', 'jest');
+export const DEFAULT_JEST_DEBUG_PATH_WINDOWS = path.join('node_modules', 'jest', 'bin', 'jest.js');
 
 export const TERMINAL_NAME = 'JestRunIt';

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,3 +4,5 @@ export type TestableNode = {
   type: 'it' | 'describe' | 'root';
   children: Array<TestableNode>;
 };
+
+export type ArgumentQuotesMode = 'none' | 'auto' | 'single' | 'double';


### PR DESCRIPTION
I encountered three problems with running / debugging tests on Windows.

## Escaping special regex characters in the test name
Jest will not find a test if its name contains parenthesis, stars, question marks or any other characters having special meaning in regex.  The reason is because extension passes test name "as is", but jest expects a pattern and not just string literal.
I just added corresponding escaping.

## Jest on Windows requires using double quotes for CLI arguments
Jest on Windows does not like test file name being wrapped with single quotation mark (see an example that I added in readme.md).  

I wrote some code that tries solving this problem automatically + added a new **jestRunIt.argumentQuotesToUse** configuration option 
 for controlling this behavior:

* `auto` - use double quotes on Windows, single quotes on other operating systems
* `single` - always wrap arguments with single quotes 
* `double` - always wrap arguments with double quotes 
* `never` - do not wrap arguments with quotes

## Debugging Jest on Windows requires different default path
Debugging tests on Windows requires running different command:
`node node_modules/jest/bin/jest.js` instead of `node_modules/.bin/jest`
See [jest documentation](https://jestjs.io/docs/en/troubleshooting).

I changed the debugTest() code to pick the correct default based on the host OS.