### PR TITLE
feat: jest run options

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,16 @@
             ],
             "description": "Glob patterns to match test files",
             "scope": "window"
+          },
+          "jestRunIt.jestCLIOptions": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "string",
+              "description": "CLI Option e.g. --coverage"
+            },
+            "description": "Add CLI Options to the Jest Command e.g. https://jestjs.io/docs/en/cli",
+            "scope": "window"
           }
         }
       }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,8 @@ import { quoteTestName, getTerminal } from './extension';
 export const runTest = (filePath: string, testName?: string, updateSnapshots = false) => {
   const jestPath = getConfig(ConfigOption.JestPath) || DEFAULT_JEST_PATH;
   const jestConfigPath = getConfig(ConfigOption.JestConfigPath);
+  const runOptions = getConfig(ConfigOption.JestCLIOptions) as string[];
+
   let command = `${jestPath} ${quoteTestName(filePath)}`;
   if (testName) {
     command += ` -t ${quoteTestName(testName)}`;
@@ -17,6 +19,11 @@ export const runTest = (filePath: string, testName?: string, updateSnapshots = f
   if (updateSnapshots) {
     command += ' -u';
   }
+  if(runOptions) {
+    runOptions.forEach(option => {
+      command += ` ${option}`;
+    });
+}
   let terminal = getTerminal(TERMINAL_NAME);
   if (!terminal) {
     terminal = vscode.window.createTerminal(TERMINAL_NAME);
@@ -28,6 +35,7 @@ export const debugTest = (filePath: string, testName?: string) => {
   const editor = vscode.window.activeTextEditor;
   const jestPath = getConfig(ConfigOption.JestPath) || DEFAULT_JEST_PATH;
   const jestConfigPath = getConfig(ConfigOption.JestConfigPath);
+  const jestCLIOptions = getConfig(ConfigOption.JestCLIOptions) as string[];
   const args = [filePath];
   if (testName) {
     args.push('-t', quoteTestName(testName));
@@ -35,7 +43,12 @@ export const debugTest = (filePath: string, testName?: string) => {
   if (jestConfigPath) {
     args.push('-c', jestConfigPath as string);
   }
-  args.push('--runInBand');
+  if(jestCLIOptions) {
+      jestCLIOptions.forEach(option => {
+        args.push(option);
+      });
+  }
+  args.push('--runInBand'); 
   const debugConfig: vscode.DebugConfiguration = {
     console: 'integratedTerminal',
     internalConsoleOptions: 'neverOpen',

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export enum ConfigOption {
   UpdateSnapshotsLabel = 'updateSnapshotsLabel',
   TestMatchPatterns = 'testMatchPatterns',
   CustomSnapshotMatchers = 'customSnapshotMatchers',
+  JestCLIOptions = 'jestCLIOptions'
 }
 
 export type JestRunItConfig = Omit<


### PR DESCRIPTION
Issue #15 

Add run options array in extension setting to be able to customize Jest CLI run (https://jestjs.io/docs/en/cli.html#options)

![image](https://user-images.githubusercontent.com/20163300/81142166-269a2700-8f6f-11ea-998f-c6bce3af8455.png)

