### PR TITLE
Fix debug test to escape special regex characters in file path

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -67,7 +67,7 @@ export const debugTest = (filePath: string, testName?: string) => {
   const environmentVarialbes = getConfig(
     ConfigOption.EnvironmentVariables
   ) as string;
-  const args = [filePath];
+  const args = [quoteTestName(filePath)];
   if (testName) {
     args.push('-t', quoteTestName(testName, 'none'));
   }


### PR DESCRIPTION
Solves #19

Also, solves the jest matching pattern issue on debug test

```
No tests found
In C:\projects\MyApp
  7266 files checked.
  testMatch: **/__tests__/**/*.js?(x),**/?(*.)(spec|test).js?(x) - 129 matches
  testPathIgnorePatterns: \\node_modules\\ - 7266 matches
Pattern: "c:\projects\MyApp\src\components\tests\header.test.js" - 0 matches
```